### PR TITLE
fix: print errors to stderr

### DIFF
--- a/output.txt
+++ b/output.txt
@@ -1,0 +1,2 @@
+Are you nobody, too?
+How dreary to be somebody!

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,12 @@ use minigrep::Config;
 fn main() {
     let vars: Vec<String> = env::args().skip(1).collect();
     let config = Config::new(&vars).unwrap_or_else(|err| {
-        println!("Problem parsing arguments: {}", err);
+        eprintln!("Problem parsing arguments: {}", err);
         process::exit(1)
     });
 
     if let Err(e) = minigrep::run(config) {
-        println!("Application error: {}", e);
+        eprintln!("Application error: {}", e);
 
         process::exit(1)
     }


### PR DESCRIPTION
- [x] errors formerly sent to stdout now go to stderr
- example: `cargo run > output.txt` now prints a stderr message instead of writing to file